### PR TITLE
Smoother shading

### DIFF
--- a/code/src/hillshade/cpp/hillshade/application.cpp
+++ b/code/src/hillshade/cpp/hillshade/application.cpp
@@ -147,7 +147,7 @@ namespace hillshade
                 ImGui::Text("Theta: %.1f  Phi: %.1f", stf::math::to_degrees(m_camera.theta), stf::math::to_degrees(m_camera.phi));
 
                 stff::vec3 light_dir = light_direction(m_azimuth, m_altitude);
-                ImGui::Text("Light direction: (%.1f, %.1f, %.1f)", light_dir.x, light_dir.y, light_dir.z);
+                ImGui::Text("Light direction: (%.3f, %.3f, %.3f)", light_dir.x, light_dir.y, light_dir.z);
                 ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
             }
 

--- a/code/src/hillshade/cpp/hillshade/application.cpp
+++ b/code/src/hillshade/cpp/hillshade/application.cpp
@@ -189,7 +189,7 @@ namespace hillshade
         }
 
         consts->albedo = m_albedo.as_vec();
-        
+
         consts->light_dir = light_direction(m_azimuth, m_altitude);
         consts->ambient_intensity = m_ambient_intensity;
         

--- a/code/src/hillshade/cpp/hillshade/application.cpp
+++ b/code/src/hillshade/cpp/hillshade/application.cpp
@@ -35,13 +35,17 @@ namespace hillshade
     struct constants
     {
         stff::mtx4 view_proj;
+
         stff::vec4 bounds;
         stff::vec4 resolution;
         stff::vec4 albedo;
+
         stff::vec3 light_dir;
         float ambient_intensity;
+
         stff::vec3 eye;
         float exaggeration;
+
         float step_scalar;
     };
 
@@ -172,7 +176,7 @@ namespace hillshade
         m_immediate_context->ClearDepthStencil(dsv, Diligent::CLEAR_DEPTH_FLAG, 1.f, 0, Diligent::RESOURCE_STATE_TRANSITION_MODE_TRANSITION);
 
         Diligent::MapHelper<constants> consts(m_immediate_context, m_shader_constants, Diligent::MAP_WRITE, Diligent::MAP_FLAG_DISCARD);
-        
+
         m_camera.aspect = aspect_ratio();
         consts->view_proj = m_camera.perspective() * m_camera.view();
 
@@ -183,13 +187,15 @@ namespace hillshade
             stff::vec2 res = stff::vec2(static_cast<float>(m_terrain->width()), static_cast<float>(m_terrain->height()));
             consts->resolution = stff::vec4(res, 1.0f / res);
         }
-        
+
         consts->albedo = m_albedo.as_vec();
+        
         consts->light_dir = light_direction(m_azimuth, m_altitude);
         consts->ambient_intensity = m_ambient_intensity;
         
         consts->eye = m_camera.eye;
         consts->exaggeration = m_exaggeration;
+
         consts->step_scalar = m_step_scalar;
 
         // set the pipeline state in the immediate context

--- a/code/src/hillshade/cpp/hillshade/application.cpp
+++ b/code/src/hillshade/cpp/hillshade/application.cpp
@@ -40,6 +40,7 @@ namespace hillshade
         stff::vec4 albedo;
         stff::vec3 light_dir;
         float ambient_intensity;
+        stff::vec3 eye;
         float exaggeration;
     };
 
@@ -172,7 +173,7 @@ namespace hillshade
         
         m_camera.aspect = aspect_ratio();
         consts->view_proj = m_camera.perspective() * m_camera.view();
-        
+
         if (m_terrain)
         {
             stff::aabb2 bounds = m_terrain->bounds().as<float>();
@@ -184,6 +185,8 @@ namespace hillshade
         consts->albedo = m_albedo.as_vec();
         consts->light_dir = light_direction(m_azimuth, m_altitude);
         consts->ambient_intensity = m_ambient_intensity;
+        
+        consts->eye = m_camera.eye;
         consts->exaggeration = m_exaggeration;
 
         // set the pipeline state in the immediate context

--- a/code/src/hillshade/cpp/hillshade/application.cpp
+++ b/code/src/hillshade/cpp/hillshade/application.cpp
@@ -42,6 +42,7 @@ namespace hillshade
         float ambient_intensity;
         stff::vec3 eye;
         float exaggeration;
+        float step_scalar;
     };
 
     application::application() {}
@@ -138,7 +139,7 @@ namespace hillshade
                 ImGui::DragFloat("altitude", &m_altitude, 0.5f, 0.f, 90.f, "%.1f");
                 ImGui::DragFloat("ambient", &m_ambient_intensity, 0.01f, 0.f, 1.f, "%.2f");
                 ImGui::DragFloat("exaggeration", &m_exaggeration, 0.01f, 0.f, 10.f, "%.2f");
-                ImGui::DragFloat("delta scalar", &m_delta_scalar, 0.0001f, 0.f, 0.01f, "%.4f");
+                ImGui::DragFloat("step scalar", &m_step_scalar, 0.0001f, 0.f, 0.01f, "%.4f");
             }
             ImGui::Separator();
             // info block
@@ -189,6 +190,7 @@ namespace hillshade
         
         consts->eye = m_camera.eye;
         consts->exaggeration = m_exaggeration;
+        consts->step_scalar = m_step_scalar;
 
         // set the pipeline state in the immediate context
         m_immediate_context->SetPipelineState(m_pso);

--- a/code/src/hillshade/cpp/hillshade/application.cpp
+++ b/code/src/hillshade/cpp/hillshade/application.cpp
@@ -138,6 +138,7 @@ namespace hillshade
                 ImGui::DragFloat("altitude", &m_altitude, 0.5f, 0.f, 90.f, "%.1f");
                 ImGui::DragFloat("ambient", &m_ambient_intensity, 0.01f, 0.f, 1.f, "%.2f");
                 ImGui::DragFloat("exaggeration", &m_exaggeration, 0.01f, 0.f, 10.f, "%.2f");
+                ImGui::DragFloat("delta scalar", &m_delta_scalar, 0.0001f, 0.f, 0.01f, "%.4f");
             }
             ImGui::Separator();
             // info block

--- a/code/src/hillshade/cpp/hillshade/main.cpp
+++ b/code/src/hillshade/cpp/hillshade/main.cpp
@@ -50,6 +50,7 @@ LRESULT CALLBACK MessageProc(HWND wnd, UINT message, WPARAM w_param, LPARAM l_pa
 
         case WM_CHAR:
             if (w_param == VK_ESCAPE) { PostQuitMessage(0); }
+            if (w_param == L'q') { PostQuitMessage(0); }
             // hide/show ui
             if (w_param == L'U' || w_param == L'u') { s_app->toggle_ui(); }
             // small zooming

--- a/code/src/hillshade/include/private/hillshade/application.h
+++ b/code/src/hillshade/include/private/hillshade/application.h
@@ -79,7 +79,7 @@ namespace hillshade
         float m_altitude = 50.f;
         float m_ambient_intensity = 0.0f;
         float m_exaggeration = 1.0f;
-        float m_delta_scalar = 0.001f;
+        float m_step_scalar = 0.001f;
 
     private:
 

--- a/code/src/hillshade/include/private/hillshade/application.h
+++ b/code/src/hillshade/include/private/hillshade/application.h
@@ -79,6 +79,7 @@ namespace hillshade
         float m_altitude = 50.f;
         float m_ambient_intensity = 0.0f;
         float m_exaggeration = 1.0f;
+        float m_delta_scalar = 0.001f;
 
     private:
 

--- a/code/src/hillshade/shaders/hillshade.psh
+++ b/code/src/hillshade/shaders/hillshade.psh
@@ -8,6 +8,17 @@ cbuffer PSConstants
     constants g_pconstants;
 };
 
+float compute_delta_uv(float3 pos, float3 eye, float4 bounds, float4 res)
+{
+    float eps = 0.001;
+    float dist = length(pos - eye);
+    float delta_world = eps * dist;
+    float delta_uv = delta_world / (bounds.z - bounds.x);
+
+    float threshold = 0.5 * res.z; // step must be at least half a texel
+    return max(threshold, delta_uv);
+}
+
 float3 normal_at(float2 uv, float4 bounds, float delta_uv)
 {
     // compute uv coords
@@ -37,7 +48,7 @@ float3 hillshade(float3 albedo, float3 light_dir, float ambient_intensity, float
 
 void main(in PSInput pixel_input, out PSOutput pixel_output)
 {
-    float delta_uv = 0.5 * g_pconstants.terrain_resolution.z;    // step is half a texel in the x direction
+    float delta_uv = compute_delta_uv(pixel_input.world_pos, g_pconstants.eye, g_pconstants.bounds, g_pconstants.terrain_resolution);
     float3 normal = normal_at(pixel_input.uv, g_pconstants.bounds, delta_uv);
     float3 shading = hillshade(g_pconstants.albedo.rgb, g_pconstants.light_dir, g_pconstants.ambient_intensity, normal, g_pconstants.exaggeration);
     pixel_output.color = float4(shading, 1.0);

--- a/code/src/hillshade/shaders/hillshade.psh
+++ b/code/src/hillshade/shaders/hillshade.psh
@@ -1,13 +1,4 @@
-struct constants
-{
-    float4x4 view_proj;
-    float4 bounds;
-    float4 terrain_resolution;
-    float4 albedo;
-    float3 light_dir;
-    float ambient_intensity;
-    float exaggeration;
-};
+#include "shaders/structures.fxh"
 
 Texture2D       g_terrain;
 SamplerState    g_terrain_sampler;
@@ -15,17 +6,6 @@ SamplerState    g_terrain_sampler;
 cbuffer PSConstants
 {
     constants g_pconstants;
-};
-
-struct PSInput
-{ 
-    float4 pos  : SV_POSITION; 
-    float2 uv   : TEX_COORD; 
-};
-
-struct PSOutput
-{ 
-    float4 color : SV_TARGET; 
 };
 
 float3 normal_at(float2 uv, float4 bounds, float delta_uv)

--- a/code/src/hillshade/shaders/hillshade.psh
+++ b/code/src/hillshade/shaders/hillshade.psh
@@ -8,11 +8,10 @@ cbuffer PSConstants
     constants g_pconstants;
 };
 
-float compute_delta_uv(float3 pos, float3 eye, float4 bounds, float4 res)
+float compute_delta_uv(float3 pos, float3 eye, float step_scalar, float4 bounds, float4 res)
 {
-    float eps = 0.001;
     float dist = length(pos - eye);
-    float delta_world = eps * dist;
+    float delta_world = step_scalar * dist;
     float delta_uv = delta_world / (bounds.z - bounds.x);
 
     float threshold = 0.5 * res.z; // step must be at least half a texel
@@ -48,7 +47,7 @@ float3 hillshade(float3 albedo, float3 light_dir, float ambient_intensity, float
 
 void main(in PSInput pixel_input, out PSOutput pixel_output)
 {
-    float delta_uv = compute_delta_uv(pixel_input.world_pos, g_pconstants.eye, g_pconstants.bounds, g_pconstants.terrain_resolution);
+    float delta_uv = compute_delta_uv(pixel_input.world_pos, g_pconstants.eye, g_pconstants.step_scalar, g_pconstants.bounds, g_pconstants.terrain_resolution);
     float3 normal = normal_at(pixel_input.uv, g_pconstants.bounds, delta_uv);
     float3 shading = hillshade(g_pconstants.albedo.rgb, g_pconstants.light_dir, g_pconstants.ambient_intensity, normal, g_pconstants.exaggeration);
     pixel_output.color = float4(shading, 1.0);

--- a/code/src/hillshade/shaders/hillshade.psh
+++ b/code/src/hillshade/shaders/hillshade.psh
@@ -28,15 +28,13 @@ struct PSOutput
     float4 color : SV_TARGET; 
 };
 
-float3 normal_at(float2 uv, float4 bounds, float4 res)
+float3 normal_at(float2 uv, float4 bounds, float delta_uv)
 {
-    float step = 0.5 * res.z;    // step is half a texel in the x direction
-
     // compute uv coords
-    float2 east_uv  = uv + float2(step, 0);
-    float2 west_uv  = uv - float2(step, 0);
-    float2 north_uv = uv - float2(0, step);
-    float2 south_uv = uv + float2(0, step);
+    float2 east_uv  = uv + float2(delta_uv, 0);
+    float2 west_uv  = uv - float2(delta_uv, 0);
+    float2 north_uv = uv - float2(0, delta_uv);
+    float2 south_uv = uv + float2(0, delta_uv);
 
     // sample elevation vlaues
     float east_z  = g_terrain.Sample(g_terrain_sampler, east_uv).r;
@@ -45,8 +43,8 @@ float3 normal_at(float2 uv, float4 bounds, float4 res)
     float south_z = g_terrain.Sample(g_terrain_sampler, south_uv).r;
 
     // compute normal vector
-    float delta = step * (bounds.z - bounds.x);
-    float3 normal = float3(west_z - east_z, south_z - north_z, 2.0 * delta);
+    float delta_world = delta_uv * (bounds.z - bounds.x);
+    float3 normal = float3(west_z - east_z, south_z - north_z, 2.0 * delta_world);
     return normalize(normal);
 }
 
@@ -59,7 +57,8 @@ float3 hillshade(float3 albedo, float3 light_dir, float ambient_intensity, float
 
 void main(in PSInput pixel_input, out PSOutput pixel_output)
 {
-    float3 normal = normal_at(pixel_input.uv, g_pconstants.bounds, g_pconstants.terrain_resolution);
+    float delta_uv = 0.5 * g_pconstants.terrain_resolution.z;    // step is half a texel in the x direction
+    float3 normal = normal_at(pixel_input.uv, g_pconstants.bounds, delta_uv);
     float3 shading = hillshade(g_pconstants.albedo.rgb, g_pconstants.light_dir, g_pconstants.ambient_intensity, normal, g_pconstants.exaggeration);
     pixel_output.color = float4(shading, 1.0);
 }

--- a/code/src/hillshade/shaders/hillshade.vsh
+++ b/code/src/hillshade/shaders/hillshade.vsh
@@ -1,22 +1,8 @@
-struct constants
-{
-    float4x4 view_proj;
-    float4 bounds;
-    float4 terrain_resolution;
-    float4 albedo;
-    float3 light_dir;
-    float ambient_intensity;
-};
+#include "shaders/structures.fxh"
 
 cbuffer VSConstants
 {
     constants g_vconstants;
-};
-
-struct PSInput 
-{ 
-    float4 pos  : SV_POSITION; 
-    float2 uv   : TEX_COORD;
 };
 
 void main(in uint vertex_id : SV_VertexID, out PSInput pixel_input) 

--- a/code/src/hillshade/shaders/hillshade.vsh
+++ b/code/src/hillshade/shaders/hillshade.vsh
@@ -17,5 +17,6 @@ void main(in uint vertex_id : SV_VertexID, out PSInput pixel_input)
 
     float2 pos = lerp(g_vconstants.bounds.xy, g_vconstants.bounds.zw, positions[vertex_id]);
     pixel_input.pos = mul(g_vconstants.view_proj, float4(pos, 0.0, 1.0));
+    pixel_input.world_pos = float3(pos, 0.0);
     pixel_input.uv  = float2(positions[vertex_id].x, 1.0 - positions[vertex_id].y);
 }

--- a/code/src/hillshade/shaders/structures.fxh
+++ b/code/src/hillshade/shaders/structures.fxh
@@ -1,13 +1,17 @@
 struct constants
 {
     float4x4 view_proj;
+
     float4 bounds;
     float4 terrain_resolution;
     float4 albedo;
+
     float3 light_dir;
     float ambient_intensity;
+
     float3 eye;
     float exaggeration;
+
     float step_scalar;
 };
 

--- a/code/src/hillshade/shaders/structures.fxh
+++ b/code/src/hillshade/shaders/structures.fxh
@@ -8,6 +8,7 @@ struct constants
     float ambient_intensity;
     float3 eye;
     float exaggeration;
+    float step_scalar;
 };
 
 struct PSInput 

--- a/code/src/hillshade/shaders/structures.fxh
+++ b/code/src/hillshade/shaders/structures.fxh
@@ -13,7 +13,7 @@ struct constants
 struct PSInput 
 { 
     float4 pos       : SV_POSITION;
-    float3 world_pos : NORMAL;
+    float3 world_pos : POSITION;
     float2 uv        : TEX_COORD;
 };
 

--- a/code/src/hillshade/shaders/structures.fxh
+++ b/code/src/hillshade/shaders/structures.fxh
@@ -6,13 +6,14 @@ struct constants
     float4 albedo;
     float3 light_dir;
     float ambient_intensity;
+    float3 eye;
     float exaggeration;
 };
 
 struct PSInput 
 { 
     float4 pos       : SV_POSITION;
-    //float3 world_pos : POSITION;
+    float3 world_pos : NORMAL;
     float2 uv        : TEX_COORD;
 };
 

--- a/code/src/hillshade/shaders/structures.fxh
+++ b/code/src/hillshade/shaders/structures.fxh
@@ -1,0 +1,22 @@
+struct constants
+{
+    float4x4 view_proj;
+    float4 bounds;
+    float4 terrain_resolution;
+    float4 albedo;
+    float3 light_dir;
+    float ambient_intensity;
+    float exaggeration;
+};
+
+struct PSInput 
+{ 
+    float4 pos       : SV_POSITION;
+    //float3 world_pos : POSITION;
+    float2 uv        : TEX_COORD;
+};
+
+struct PSOutput
+{ 
+    float4 color : SV_TARGET; 
+};


### PR DESCRIPTION
## Summary

This PR sets up normal computation to take a larger step in x/y when the camera is zoomed out. This results in a much prettier shading of the map.