### PR TITLE
Remove tif support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,5 @@ set(CXX_STANDARD_REQUIRED ON)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 add_subdirectory(code)
+
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT hillshade)

--- a/code/deps/CMakeLists.txt
+++ b/code/deps/CMakeLists.txt
@@ -22,5 +22,3 @@ FetchContent_Declare(
     SOURCE_DIR _deps/DiligentTools
 )
 FetchContent_MakeAvailable(DiligentCore DiligentTools)
-
-find_package(gdal CONFIG REQUIRED)

--- a/code/deps/CMakeLists.txt
+++ b/code/deps/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 FetchContent_Declare(
     stf
     GIT_REPOSITORY https://github.com/nathanstouffer/stf.git
-    GIT_TAG f89b3f9a39841aa6cc0274938000ef93d9a217e4
+    GIT_TAG 635bf857b54fbb17a5c9e8d5d465fa08afd6667c
 )
 FetchContent_MakeAvailable(stf)
 

--- a/code/src/hillshade/CMakeLists.txt
+++ b/code/src/hillshade/CMakeLists.txt
@@ -36,19 +36,21 @@ target_include_directories(hillshade
     "${CMAKE_CURRENT_SOURCE_DIR}/include/private"
 )
 
+# add small dependencies
 target_link_libraries(hillshade
     PRIVATE
     stf
     nlohmann_json::nlohmann_json
-    Diligent-Common
-    Diligent-TextureLoader
-    Diligent-Imgui
 )
 
-# TODO figure out how to staticly link libraries? not sure if it's possible?
+# add diligent dependencies
 target_link_libraries(hillshade
     PRIVATE
     Diligent-BuildSettings
+    Diligent-Common
+    Diligent-TextureLoader
+    Diligent-Imgui
+    # rendering dependencies
     Diligent-GraphicsEngineOpenGL-shared
 )
 copy_required_dlls(hillshade)

--- a/code/src/hillshade/CMakeLists.txt
+++ b/code/src/hillshade/CMakeLists.txt
@@ -26,13 +26,16 @@ target_compile_definitions(hillshade
 
 # TODO figure out why we need to explicitly make this available here
 FetchContent_MakeAvailable(DiligentCore DiligentTools)
+find_package(nlohmann_json CONFIG REQUIRED)
+find_package(Stb REQUIRED)
 
 target_include_directories(hillshade
     PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/private"
     "${diligentcore_SOURCE_DIR}"
     "${diligenttools_SOURCE_DIR}"
     "${DILIGENT_DEAR_IMGUI_PATH}"
+    "${Stb_INCLUDE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/private"
 )
 
 target_link_directories(hillshade
@@ -44,6 +47,7 @@ target_link_directories(hillshade
 target_link_libraries(hillshade
     PRIVATE
     stf
+    nlohmann_json::nlohmann_json
     DiligentCore
     DiligentTools
 )

--- a/code/src/hillshade/CMakeLists.txt
+++ b/code/src/hillshade/CMakeLists.txt
@@ -32,7 +32,6 @@ target_include_directories(hillshade
     PRIVATE
     "${diligentcore_SOURCE_DIR}"
     "${diligenttools_SOURCE_DIR}"
-    "${DILIGENT_DEAR_IMGUI_PATH}"
     "${Stb_INCLUDE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/include/private"
 )

--- a/code/src/hillshade/CMakeLists.txt
+++ b/code/src/hillshade/CMakeLists.txt
@@ -26,7 +26,6 @@ target_compile_definitions(hillshade
 
 # TODO figure out why we need to explicitly make this available here
 FetchContent_MakeAvailable(DiligentCore DiligentTools)
-find_package(gdal CONFIG REQUIRED)
 
 target_include_directories(hillshade
     PRIVATE
@@ -34,7 +33,6 @@ target_include_directories(hillshade
     "${diligentcore_SOURCE_DIR}"
     "${diligenttools_SOURCE_DIR}"
     "${DILIGENT_DEAR_IMGUI_PATH}"
-    "${gdal_INCLUDE_DIRS}"
 )
 
 target_link_directories(hillshade

--- a/code/src/hillshade/CMakeLists.txt
+++ b/code/src/hillshade/CMakeLists.txt
@@ -46,7 +46,6 @@ target_link_libraries(hillshade
     stf
     DiligentCore
     DiligentTools
-    GDAL::GDAL
 )
 
 # TODO figure out how to staticly link libraries? not sure if it's possible?

--- a/code/src/hillshade/CMakeLists.txt
+++ b/code/src/hillshade/CMakeLists.txt
@@ -37,18 +37,13 @@ target_include_directories(hillshade
     "${CMAKE_CURRENT_SOURCE_DIR}/include/private"
 )
 
-target_link_directories(hillshade
-    PRIVATE
-    "${diligentcore_BINARY_DIR}"
-    "${diligenttools_BINARY_DIR}"
-)
-
 target_link_libraries(hillshade
     PRIVATE
     stf
     nlohmann_json::nlohmann_json
-    DiligentCore
-    DiligentTools
+    Diligent-Common
+    Diligent-TextureLoader
+    Diligent-Imgui
 )
 
 # TODO figure out how to staticly link libraries? not sure if it's possible?

--- a/code/src/hillshade/CMakeLists.txt
+++ b/code/src/hillshade/CMakeLists.txt
@@ -14,7 +14,6 @@ add_executable(hillshade WIN32 ${HILLSHADE_FILES})
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}/" FILES ${HILLSHADE_FILES})
 
 file(CREATE_LINK "${CMAKE_CURRENT_SOURCE_DIR}/shaders" "${CMAKE_CURRENT_BINARY_DIR}/shaders" SYMBOLIC)
-file(CREATE_LINK "${CMAKE_SOURCE_DIR}/tiff" "${CMAKE_CURRENT_BINARY_DIR}/tiff" SYMBOLIC)
 file(CREATE_LINK "${CMAKE_SOURCE_DIR}/terrarium" "${CMAKE_CURRENT_BINARY_DIR}/terrarium" SYMBOLIC)
 
 # TODO eventually we should split this out by platform

--- a/code/src/hillshade/cpp/hillshade/application.cpp
+++ b/code/src/hillshade/cpp/hillshade/application.cpp
@@ -33,7 +33,6 @@ namespace hillshade
 
     static constexpr char* c_start_up_file = "startup.json";
     static constexpr char* c_shader_dir = "shaders";
-    static constexpr char* c_tiff_dir = "tiff";
     static constexpr char* c_terrarium_dir = "terrarium";
 
     static constexpr double c_min_meters_per_quad = 5.0;
@@ -121,20 +120,6 @@ namespace hillshade
         // debug window
         {
             ImGui::BeginMainMenuBar();
-
-            if (ImGui::BeginMenu("tiff"))
-            {
-                for (std::filesystem::directory_entry const& file : std::filesystem::directory_iterator(c_tiff_dir))
-                {
-                    std::string path = file.path().string();
-                    bool selected = m_dem_path == path;
-                    if (ImGui::MenuItem(file.path().stem().generic_string().c_str(), nullptr, selected, !selected))
-                    {
-                        load_dem(path);
-                    }
-                }
-                ImGui::EndMenu();
-            }
 
             if (ImGui::BeginMenu("terrarium"))
             {

--- a/code/src/hillshade/cpp/hillshade/main.cpp
+++ b/code/src/hillshade/cpp/hillshade/main.cpp
@@ -4,8 +4,6 @@
 #include <Windows.h>
 #include <crtdbg.h>
 
-#include <gdal_priv.h>
-
 #include "hillshade/application.hpp"
 
 static std::unique_ptr<hillshade::application> s_app = nullptr;
@@ -93,9 +91,6 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
 #if defined(_DEBUG) || defined(DEBUG)
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
-
-    // register gdal
-    GDALAllRegister();
 
     // register window
     WNDCLASSEX wcex = { sizeof(WNDCLASSEX), CS_HREDRAW | CS_VREDRAW, MessageProc, 0L, 0L, hInstance, NULL, NULL, NULL, NULL, "Hillshade", NULL };

--- a/code/src/hillshade/include/private/hillshade/terrain.hpp
+++ b/code/src/hillshade/include/private/hillshade/terrain.hpp
@@ -25,27 +25,11 @@ namespace hillshade
 
     private:
 
-        void load_tif(std::filesystem::path const& path);
-        void load_terrarium(std::filesystem::path const& path);
-
-    private:
-
         size_t m_width;
         size_t m_height;
         std::vector<float> m_values;
 
         stff::interval m_range;
-
-        // https://gdal.org/en/release-3.10/tutorials/geotransforms_tut.html#geotransforms-tut
-        // [
-        //   0: x coordinate of upper-left corner of upper-left pixel
-        //   1: west-east pixel resolution / pixel width
-        //   2: row rotation (typically zero)
-        //   3: y coord of the upper-left corner of the upper-left pixel
-        //   4: column rotation (typically zero)
-        //   5: north-south pixel resolution / pixel height (negative value for a north-up image)
-        // ]
-        std::array<double, 6> m_geo_transform;
 
         stfd::aabb2 m_bounds;
 

--- a/readme.md
+++ b/readme.md
@@ -8,4 +8,4 @@ An exploration in hillshading for topographic maps
 1. `docker compose build && docker compose run --rm convert`
 1. Generate VS project file with `make generate-vs-project`
     - note: relies on a symbolic link (you may need to enable `For developers` on Windows)
-1. Build and run with VS
+1. Build and run `.build/Win64/hillshade.sln` with VS

--- a/readme.md
+++ b/readme.md
@@ -4,8 +4,8 @@ An exploration in hillshading for topographic maps
 
 ## running
 
-1. Put any tiffs in `./tiff`
-1. `docker compose build && docker compose run --rm convert` (optional)
-1. Generate VS project file with `make gnerate-vs-project`
+1. Put tiffs in `./tiff`
+1. `docker compose build && docker compose run --rm convert`
+1. Generate VS project file with `make generate-vs-project`
     - note: relies on a symbolic link (you may need to enable `For developers` on Windows)
 1. Build and run with VS

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,15 +2,10 @@
   "name": "hillshade",
   "version-semver": "0.0.0",
   "dependencies": [
-    "gdal",
     "nlohmann-json",
     "stb"
   ],
   "overrides": [
-    {
-      "name": "gdal",
-      "version": "3.10.0"
-    }
   ],
   "builtin-baseline": "10b7a178346f3f0abef60cecd5130e295afd8da4"
 }


### PR DESCRIPTION
## Summary

This PR removes TIF support since installing GDAL takes up a lot of hard drive space. That job is now handled by a docker container that converts from tiffs to terrarium-encoded PNGs.

In addition to that, I corrected some link dependencies in the CMake configuration and set the `hillshade` executable as the start up project.